### PR TITLE
Checking resource.duration != initial in totalDuration sum

### DIFF
--- a/confess.js
+++ b/confess.js
@@ -90,7 +90,9 @@ var confess = {
                 if (!fastest || resource.duration < fastest.duration) {
                     fastest = resource;
                 }
-                totalDuration += resource.duration;
+                if (resource.duration != '-'){
+                    totalDuration += resource.duration;
+                }
 
                 if (resource.size) {
                     if (!largest || resource.size > largest.size) {


### PR DESCRIPTION
When a resource is not propperly loaded, it keeps its original value '-', so in the addition operation for totalDuration javascript treats it as a string and give as a result 'time1-time2-time3-...' which it shouldn't.

You can try this error using as url 'http://www.marca.com/'
